### PR TITLE
Bump to netatalk 2.230301

### DIFF
--- a/scripts/a2server-3-sharing.txt
+++ b/scripts/a2server-3-sharing.txt
@@ -120,12 +120,12 @@ else
     cd /tmp/netatalk
     
     if [[ $useExternalURL ]]; then
-	wget -qO netatalk-2-230202.tar.gz "https://github.com/rdmark/netatalk-2.x/releases/download/netatalk-2-230202/netatalk-2.230202.tar.gz"
-	tar xzf netatalk-2-230202.tar.gz &> /dev/null
+	wget -qO netatalk-2-230301.tar.gz "https://github.com/rdmark/netatalk-2.x/releases/download/netatalk-2-230301/netatalk-2.230301.tar.gz"
+	tar xzf netatalk-2-230301.tar.gz &> /dev/null
 
     fi
 
-    cd netatalk-2.230202
+    cd netatalk-2.230301
 
     # prepare to build Netatalk
     ./configure --enable-systemd --enable-cups --disable-quota


### PR DESCRIPTION
Primarily fixes the systemd configs to make the services start up more reliably on wifi only RPis.

https://github.com/rdmark/netatalk-2.x/releases/tag/netatalk-2-230301