### PR TITLE
Add TashTalk Hat Support to A2SERVER

### DIFF
--- a/scripts/a2server-3-sharing.txt
+++ b/scripts/a2server-3-sharing.txt
@@ -278,6 +278,81 @@ if [[ $(tac /usr/local/etc/netatalk/atalkd.conf | sed '/./,$!d' | head -1 | cut 
     fi
 fi
 
+if [[ $isRpi ]];then
+    # find config.txt
+    if [ -e /boot/firmware/config.txt ] ; then
+        FIRMWARE=/firmware
+    else
+        FIRMWARE=
+    fi
+    if [ -e /proc/device-tree/chosen/os_prefix ]; then
+        PREFIX="$(tr -d '\0' < /proc/device-tree/chosen/os_prefix)"
+    fi
+    # set location for config.txt and cmdline.txt
+    CMDLINE="/boot${FIRMWARE}/${PREFIX}cmdline.txt"
+    CONFIG=/boot${FIRMWARE}/config.txt
+    
+    # check for existing install
+    tashtalkInstalled=
+    if [[ $(grep "dtoverlay=miniuart-bt" $CONFIG) && \
+        $(grep "gpio=16-17=a3" $CONFIG) && \
+        $(grep "enable_uart=1" $CONFIG) ]]; then
+        tashtalkInstalled=1
+    fi
+    # check for serial port console
+    consoleInstalled=
+    if [[ $(grep "console=ttyAMA0" $CMDLINE) || \
+        $(grep "console=serial0" $CMDLINE) ]];then
+        consoleInstalled=1
+    fi
+    [[ -f /tmp/a2server-autoAnswerYes ]] && autoAnswerYes=1 || autoAnswerYes=
+    REPLY=
+    if [[ ! $autoAnswerYes || -f /tmp/a2server-setupTashtalk ]]; then
+        if [[ ! $tashtalkInstalled || $consoleInstalled ]];then
+            echo
+            echo "A2SERVER supports LocalTalk connectivity via a TashTalk Hat."
+            echo "If you own one of these devices, you can set it up now."
+            echo
+            echo "NOTE: This will disable any serial consoles set up on this machine."
+            echo "You will be prompted to reboot after A2SERVER setup to activate your TashTalk."
+            echo
+            echo -n "Do you want to setup a TashTalk Hat to use with A2SERVER? "
+            read
+        else
+            echo "TashTalk Hat already set up."
+        fi
+    fi
+    if [[ $autoAnswerYes || ${REPLY:0:1} == "Y" || ${REPLY:0:1} == "y" ]]; then
+        sudo true
+        sudo apt-get install --no-install-recommends --assume-yes python3-serial
+        # disable serial console
+        sudo sed -i $CMDLINE -e "s/console=ttyAMA0,[0-9]\+ //"
+        sudo sed -i $CMDLINE -e "s/console=serial0,[0-9]\+ //"
+
+        # add required lines to config.txt
+        if [[ ! $(grep "dtoverlay=miniuart-bt" $CONFIG) ]];then
+            sudo echo -e "dtoverlay=miniuart-bt" | tee -a $CONFIG > /dev/null
+        fi
+
+        if [[ ! $(grep "gpio=16-17=a3" $CONFIG) ]];then
+            sudo echo -e "gpio=16-17=a3" | tee -a $CONFIG > /dev/null
+        fi
+
+        if [[ $(grep "enable_uart=" $CONFIG) ]];then
+            if [[ $(grep "enable_uart=0" $CONFIG) ]];then
+                sudo sed -i $CONFIG -e "s/enable_uart=0/enable_uart=1/"
+            fi
+        else
+            sudo echo -e "enable_uart=1" | tee -a $CONFIG > /dev/null
+        fi
+
+        # alter tashrouter configuration
+        sudo sed -i /usr/local/sbin/tashrouter.py -e "s/#from tashrouter.port.localtalk.tashtalk/from tashrouter.port.localtalk.tashtalk/"
+        sudo sed -i /usr/local/sbin/tashrouter.py -e "s/#TashTalkPort/TashTalkPort/"
+        touch /tmp/rPiupdate
+    fi
+fi
+
 if [[ $(tac /usr/local/etc/netatalk/papd.conf | sed '/./,$!d' | head -1 | cut -c 1) == "#" ]]; then
     # enable papd's auto sharing of CUPS printer queues
     echo -e 'cupsautoadd:op=root:' | sudo tee -a /usr/local/etc/netatalk/papd.conf > /dev/null

--- a/scripts/a2server-3-sharing.txt
+++ b/scripts/a2server-3-sharing.txt
@@ -349,7 +349,7 @@ if [[ $isRpi ]];then
         # alter tashrouter configuration
         sudo sed -i /usr/local/sbin/tashrouter.py -e "s/#from tashrouter.port.localtalk.tashtalk/from tashrouter.port.localtalk.tashtalk/"
         sudo sed -i /usr/local/sbin/tashrouter.py -e "s/#TashTalkPort/TashTalkPort/"
-        touch /tmp/rPiupdate
+        touch /tmp/rpiUpdate
     fi
 fi
 

--- a/scripts/a2server-3-sharing.txt
+++ b/scripts/a2server-3-sharing.txt
@@ -319,7 +319,7 @@ if [[ $isRpi ]];then
             echo -n "Do you want to setup a TashTalk Hat to use with A2SERVER? "
             read
         else
-            echo "TashTalk Hat already set up."
+            echo "A2SERVER: TashTalk Hat already set up."
         fi
     fi
     if [[ $autoAnswerYes || ${REPLY:0:1} == "Y" || ${REPLY:0:1} == "y" ]]; then

--- a/scripts/a2server-3-sharing.txt
+++ b/scripts/a2server-3-sharing.txt
@@ -331,11 +331,11 @@ if [[ $isRpi ]];then
 
         # add required lines to config.txt
         if [[ ! $(grep "dtoverlay=miniuart-bt" $CONFIG) ]];then
-            sudo echo -e "dtoverlay=miniuart-bt" | tee -a $CONFIG > /dev/null
+            echo -e "dtoverlay=miniuart-bt" | sudo tee -a $CONFIG > /dev/null
         fi
 
         if [[ ! $(grep "gpio=16-17=a3" $CONFIG) ]];then
-            sudo echo -e "gpio=16-17=a3" | tee -a $CONFIG > /dev/null
+            echo -e "gpio=16-17=a3" | sudo tee -a $CONFIG > /dev/null
         fi
 
         if [[ $(grep "enable_uart=" $CONFIG) ]];then
@@ -343,7 +343,7 @@ if [[ $isRpi ]];then
                 sudo sed -i $CONFIG -e "s/enable_uart=0/enable_uart=1/"
             fi
         else
-            sudo echo -e "enable_uart=1" | tee -a $CONFIG > /dev/null
+            echo -e "enable_uart=1" | sudo tee -a $CONFIG > /dev/null
         fi
 
         # alter tashrouter configuration

--- a/setup/index.txt
+++ b/setup/index.txt
@@ -290,9 +290,18 @@ if (( $doSetup )); then
             echo
             echo "A2SERVER setup is complete! Go connect from your Apple II!"
             echo
-        elif [[ -f /tmp/rpiUpdate ]]; then
+        else
+            echo "A2SERVER is now configured, but Apple II clients cannot connect because"
+            echo "AppleTalk networking is unavailable. Please make sure that"
+            echo "your Linux distribution has a loadable AppleTalk kernel module or"
+            echo "has AppleTalk built into the kernel, and restart your server."
+            echo "Or, if you previously disabled AppleTalk in A2SERVER, re-enable it"
+            echo "by typing 'appletalk-on'."
+            echo
+        fi
+        if [[ -f /tmp/rpiUpdate ]]; then
             echo "A2SERVER is now configured, but Apple II clients will not be able"
-            echo "to connect via your TashTalk Hat until you restart your Raspberry Pi."
+            echo "to connect via your TashTalk Hat or LToUDP until you restart your Raspberry Pi."
             echo
             if [[ ! $autoAnswerYes ]]; then
                 echo -n "Restart now? "
@@ -306,23 +315,7 @@ if (( $doSetup )); then
             fi
             rm /tmp/rpiUpdate
             echo
-        elif [[ $kernelMajorRelease -eq 3 && $kernelMinorRelease -ge 12 && $kernelMinorRelease -le 15 ]]; then
-            echo "A2SERVER is now configured, but Apple II clients cannot connect"
-            echo "because of a kernel-crashing bug in Linux kernel 3.12 through 3.15."
-            echo "You have kernel version $kernelMajorRelease.$kernelMinorRelease."
-            echo "A2SERVER has disabled AppleTalk networking to prevent crashes."
-            echo "Please use kernel 3.11 or earlier, or kernel 3.16 or later."
-            echo
-        else
-            echo "A2SERVER is now configured, but Apple II clients cannot connect because"
-            echo "AppleTalk networking is unavailable. Please make sure that"
-            echo "your Linux distribution has a loadable AppleTalk kernel module or"
-            echo "has AppleTalk built into the kernel, and restart your server."
-            echo "Or, if you previously disabled AppleTalk in A2SERVER, re-enable it"
-            echo "by typing 'appletalk-on'."
-            echo
         fi
-        
         if [[ -f /tmp/noMacIP ]]; then
             echo
             echo "MacIP connections may be unavailable. If you know how, try"

--- a/setup/index.txt
+++ b/setup/index.txt
@@ -64,6 +64,10 @@ while [[ $1 ]]; do
         shift
         setupNetBoot="-b"
         touch /tmp/a2server-setupNetBoot
+    elif [[ $1 == "-h" ]]; then
+        shift
+        setupTashtalk="-h"
+        touch /tmp/a2server-setupTashtalk
     elif [[ $1 == "-w" ]]; then
         shift
         setupWindowsSharing="-w"
@@ -91,6 +95,7 @@ while [[ $1 ]]; do
         echo "-y: auto-answer yes to all prompts"
         echo "-r: don't update package repositories"
         echo "-b: auto-setup network boot (use with -y)"
+        echo "-h: auto-setup TashTalk Hat on RPi (use with -y)"
         echo "-w: auto-setup Windows file sharing (use with -y)"
         echo "-c: compile non-package items, rather than downloading binaries"
         echo "-t: use all available CPU cores for multi threaded compilation"
@@ -118,7 +123,7 @@ unsupportedOS=1
 
 if [[ $isDebian ]]; then # supported Debian?
      debianVersion=$(cat /etc/debian_version)
-     debianSupported="-12.2- -11.8- -10.13-"
+     debianSupported="-12.5- -11.9-"
      [[ $debianSupported == *-$debianVersion-* ]] && unsupportedOS=
 fi
 
@@ -287,7 +292,7 @@ if (( $doSetup )); then
             echo
         elif [[ -f /tmp/rpiUpdate ]]; then
             echo "A2SERVER is now configured, but Apple II clients will not be able"
-            echo "to connect until you restart your Raspberry Pi."
+            echo "to connect via your TashTalk Hat until you restart your Raspberry Pi."
             echo
             if [[ ! $autoAnswerYes ]]; then
                 echo -n "Restart now? "


### PR DESCRIPTION
Add support for installing and configuring a TashTalk Hat to A2SERVER. This allows direct connection of LocalTalk clients to your Raspberry Pi!